### PR TITLE
Убрать проверки в пулреквестах с  форков

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   update-version-and-push:
-    if: github.event.pull_request.head.repo.name == github.repository
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,6 +7,7 @@ permissions:
   contents: write
 jobs:
   update-version-and-push:
+    if: github.event.pull_request.head.repo.name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,8 +15,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.UNN_MOBILE_AUTO_KEY }}
-      - run: 
-          git log --all
       - run: |
           sed -i "/version:/s/\(\([0-9]\+\.\)\{2\}[0-9]\+\)+[0-9]\+/\1+$(($(git rev-list --count origin/develop) + 1))/" pubspec.yaml
           git config --global user.name "UNN MOBILE runner"

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    if: github.event.pull_request.head.repo.name == github.repository
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    if: github.event.pull_request.head.repo.name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: unn_mobile
 description: A mobile application for UNN Portal website
 publish_to: 'none'
-version: 0.1.3+124
+version: 0.1.3+125
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
Поскольку нам надо использовать секреты при проверках - гитхаб не даст нормально выполниться проверкам на пулреквестах с форков
Неидеальное решение, но проще будет иногда проверить вручную, чем сейчас бороться с гитхабом в этом плане