### PR TITLE
Баг с экспортом расписания на ios

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -149,6 +149,8 @@ PODS:
   - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -163,6 +165,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -207,6 +210,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
@@ -236,6 +241,7 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
+  url_launcher_ios: 6116280ddcfe98ab8820085d8d76ae7449447586
 
 PODFILE CHECKSUM: 40a3af330fd84e37dd5d7962adf17c5e91699984
 

--- a/lib/core/services/implementations/export_schedule_service_impl.dart
+++ b/lib/core/services/implementations/export_schedule_service_impl.dart
@@ -73,11 +73,10 @@ class ExportScheduleServiceImpl implements ExportScheduleService {
     final status = await _permissionHandler
         .checkPermissionStatus(Permission.calendarFullAccess);
     if (status.isDenied) {
-      await _permissionHandler
+      final permissionStatuses = await _permissionHandler
           .requestPermissions([Permission.calendarFullAccess]);
-      return (await _permissionHandler
-              .checkPermissionStatus(Permission.calendarFullAccess)
-              .isGranted)
+      return (permissionStatuses[Permission.calendarFullAccess] ==
+              PermissionStatus.granted)
           ? RequestCalendarPermissionResult.allowed
           : RequestCalendarPermissionResult.rejected;
     } else if (status.isPermanentlyDenied) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: unn_mobile
 description: A mobile application for UNN Portal website
 publish_to: 'none'
-version: 0.1.3+150
+version: 0.1.3+151
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
На ios в независимости от выбора до перезапуска приложения checkPermissionStatus будет возвращать denied, а также не будет запрашиваться разрешение на доступ к календарю